### PR TITLE
[메인 화면] 유저는 일정이 등록된 캘린더를 볼 수 있다.

### DIFF
--- a/DreamCalendar/DreamCalendar/Scene/Main/MainView.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Main/MainView.swift
@@ -57,14 +57,19 @@ struct MainView: View, MainTopViewDelegate {
                     self.calendarViewIndex = CGFloat(MainViewModel.centerIndex) - (value.translation.width / proxy.size.width)
                 }
                 .onEnded { value in
+                    let index: CGFloat
                     if abs(value.translation.width) >= proxy.size.width / 2 {
-                        let addition = value.translation.width > 0 ? 0 : +1
-                        self.calendarViewIndex = CGFloat((Int(self.calendarViewIndex) + addition))
+                        let addition = value.translation.width > 0 ? 0 : 1
+                        index = CGFloat((Int(self.calendarViewIndex) + addition))
                     } else {
-                        self.calendarViewIndex = CGFloat(Int(self.calendarViewIndex))
+                        let addition = value.translation.width > 0 ? 1 : 0
+                        index = CGFloat(Int(self.calendarViewIndex) + addition)
                     }
-                    self.viewModel.changeIndex(Int(self.calendarViewIndex))
-                    self.calendarViewIndex = CGFloat(MainViewModel.centerIndex)
+                    let duration: CGFloat = ((proxy.size.width - abs(value.translation.width)) / proxy.size.width)
+                    withAnimation(.easeOut(duration: duration)) {
+                        self.calendarViewIndex = CGFloat(MainViewModel.centerIndex)
+                        self.viewModel.changeIndex(Int(index))
+                    }
                 })
         }
     }


### PR DESCRIPTION
## 작업 내용
- [x] 캘린더를 좌우로 스와이핑 시 끊김 현상 해결

fix #22
close #22

## 시연 방법

https://github.com/kau-dreamtree/ios-dream-calendar/assets/64150179/62b792f3-c9cd-497a-8a02-09cf59fbf231

## 기타 (고민과 해결, 리뷰 포인트 등)
- TabView, UIHostingController 등 다양한 방법을 시도해보았음. 최종적으로 LazyHStack을 사용한 방법 채택
- TabView
    - 장점 : 자동 페이징 가능
    - 단점 : LazyHStack과 동일한 이슈 발생
- UIHostingController
    - UICollectionViewCell로 DCCalendarView를 넣는 방법을 생각했으나, 너무 복잡하여 중단
- LazyHStack 
    - 장점 : 뷰가 appear될 때 그림
    - 단점 : offset 직접 계산하여 애니메이션 효과 부여