### PR TITLE
[네트워크] 일정 업데이트 시 서버에 업로드한다.

### DIFF
--- a/DreamCalendar/CalendarUI/Models/Schedule.swift
+++ b/DreamCalendar/CalendarUI/Models/Schedule.swift
@@ -16,12 +16,13 @@ public struct Schedule: Codable {
     let endTime: Date
     let tag: TagUI
     let isValid: Bool
+    let isNotUpdated: Bool
     
     public static func ==(lhs: Self, rhs: Self) -> Bool {
         return lhs.id == rhs.id
     }
     
-    public init(id: UUID, serverId: Int, title: String, isAllDay: Bool, startTime: Date, endTime: Date, tag: TagUI, isValid: Bool) {
+    public init(id: UUID, serverId: Int, title: String, isAllDay: Bool, startTime: Date, endTime: Date, tag: TagUI, isValid: Bool, isNotUpdated: Bool) {
         self.id = id
         self.serverId = serverId
         self.title = title
@@ -30,6 +31,7 @@ public struct Schedule: Codable {
         self.endTime = endTime
         self.tag = tag
         self.isValid = isValid
+        self.isNotUpdated = isNotUpdated
     }
     
     var length: Int {

--- a/DreamCalendar/CalendarUI/Views/WeekView.swift
+++ b/DreamCalendar/CalendarUI/Views/WeekView.swift
@@ -158,6 +158,10 @@ struct BlockView: View {
         static let width: CGFloat = 46
         static let zeroPadding: CGFloat = 0
         static let blockHorizontalInterval: CGFloat = 2
+        static let warningImageWidthHeight: CGFloat = 10
+        static let warningImageTextInterval: CGFloat = 1
+        
+        static let warningImageName: String = "exclamationmark.triangle"
     }
     
     init(schedule: ScheduleBlock?, in week: Week) {
@@ -172,14 +176,36 @@ struct BlockView: View {
     
     var body: some View {
         ZStack {
-            Text(schedule?.title ?? "공백")
-                .font(.AppleSDBold12)
-                .foregroundColor(schedule?.fontColor ?? .clear)
-                .frame(height: Constraint.height, alignment: .center)
+            HStack(spacing: 0) {
+                if schedule?.schedule.isNotUpdated == true {
+                    self.warningImage
+                }
+                self.title
+            }
         }
         .frame(width: self.width, height: Constraint.height)
         .background(schedule?.backgroundColor ?? .clear)
         .cornerRadius(Constraint.cornerRadius)
+    }
+    
+    private var warningImage: some View {
+        Image(systemName: Constraint.warningImageName)
+            .resizable()
+            .foregroundColor(schedule?.fontColor ?? .gray)
+            .frame(width: Constraint.warningImageWidthHeight,
+                   height: Constraint.warningImageWidthHeight,
+                   alignment: .center)
+            .padding(EdgeInsets(top: Constraint.zeroPadding,
+                                leading: Constraint.zeroPadding,
+                                bottom: Constraint.zeroPadding,
+                                trailing: Constraint.warningImageTextInterval))
+    }
+    
+    private var title: some View {
+        Text(schedule?.title ?? "공백")
+            .font(.AppleSDBold12)
+            .foregroundColor(schedule?.fontColor ?? .clear)
+            .frame(height: Constraint.height, alignment: .center)
     }
 }
 

--- a/DreamCalendar/DreamCalendar.xcodeproj/project.pbxproj
+++ b/DreamCalendar/DreamCalendar.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		4A08422628EA99FC003E70A4 /* DreamCalendarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08422528EA99FC003E70A4 /* DreamCalendarTests.swift */; };
 		4A08423028EA99FC003E70A4 /* DreamCalendarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08422F28EA99FC003E70A4 /* DreamCalendarUITests.swift */; };
 		4A08423228EA99FC003E70A4 /* DreamCalendarUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08423128EA99FC003E70A4 /* DreamCalendarUITestsLaunchTests.swift */; };
+		4A0C2E8F2A5553D30008B815 /* Extension+NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0C2E8E2A5553D30008B815 /* Extension+NotificationCenter.swift */; };
+		4A0C2E912A5559580008B815 /* WarningImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0C2E902A5559580008B815 /* WarningImage.swift */; };
+		4A0C2E922A55595B0008B815 /* WarningImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0C2E902A5559580008B815 /* WarningImage.swift */; };
 		4A27D0D729289050007FC2DD /* ScheduleAdditionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A27D0D629289050007FC2DD /* ScheduleAdditionView.swift */; };
 		4A27D0DA2928A217007FC2DD /* MainTopMiddleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A27D0D92928A217007FC2DD /* MainTopMiddleView.swift */; };
 		4A27D0DC2928A224007FC2DD /* MainTopLeftView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A27D0DB2928A224007FC2DD /* MainTopLeftView.swift */; };
@@ -235,6 +238,8 @@
 		4A08422B28EA99FC003E70A4 /* DreamCalendarUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DreamCalendarUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A08422F28EA99FC003E70A4 /* DreamCalendarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamCalendarUITests.swift; sourceTree = "<group>"; };
 		4A08423128EA99FC003E70A4 /* DreamCalendarUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamCalendarUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		4A0C2E8E2A5553D30008B815 /* Extension+NotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+NotificationCenter.swift"; sourceTree = "<group>"; };
+		4A0C2E902A5559580008B815 /* WarningImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningImage.swift; sourceTree = "<group>"; };
 		4A27D0D629289050007FC2DD /* ScheduleAdditionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleAdditionView.swift; sourceTree = "<group>"; };
 		4A27D0D92928A217007FC2DD /* MainTopMiddleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTopMiddleView.swift; sourceTree = "<group>"; };
 		4A27D0DB2928A224007FC2DD /* MainTopLeftView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTopLeftView.swift; sourceTree = "<group>"; };
@@ -367,6 +372,7 @@
 				4A0724532918B607005AA8B7 /* Main */,
 				4A301CD5298CF4FA005ACE70 /* ExitButton.swift */,
 				4A301CD7298CF6DB005ACE70 /* Logo.swift */,
+				4A0C2E902A5559580008B815 /* WarningImage.swift */,
 			);
 			path = Scene;
 			sourceTree = "<group>";
@@ -509,6 +515,7 @@
 				4AD96EF72928B76A00C31C06 /* Date+Extension.swift */,
 				4AAC0A482931DBB5009CB29C /* Tag+Extension.swift */,
 				4AD00592295982CA00041173 /* Alert+Extension.swift */,
+				4A0C2E8E2A5553D30008B815 /* Extension+NotificationCenter.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -899,6 +906,7 @@
 				4AD005FA2959927100041173 /* Tag+CoreDataClass.swift in Sources */,
 				4A301CD2298CD917005ACE70 /* SignupView.swift in Sources */,
 				4A27D0D729289050007FC2DD /* ScheduleAdditionView.swift in Sources */,
+				4A0C2E912A5559580008B815 /* WarningImage.swift in Sources */,
 				4AF36EB32981184A00338B7A /* HalfSheetController.swift in Sources */,
 				4AAC0A452931D9DB009CB29C /* TimeInfo.swift in Sources */,
 				4AD005FF295992A900041173 /* Schedule+CoreDataProperties.swift in Sources */,
@@ -921,6 +929,7 @@
 				4A301CCC298BB224005ACE70 /* DCAccountAPI.swift in Sources */,
 				4A97D2932A33911F0041EB6F /* DCScheduleAPI.swift in Sources */,
 				4A54DD6529CC2BDA005A3E20 /* DeveloperConfiguration.swift in Sources */,
+				4A0C2E8F2A5553D30008B815 /* Extension+NotificationCenter.swift in Sources */,
 				4A301CD4298CEC9A005ACE70 /* SignupViewModel.swift in Sources */,
 				4A0724572918B647005AA8B7 /* MainTopView.swift in Sources */,
 				4AD005F22959927100041173 /* TagUpdateLog+CoreDataClass.swift in Sources */,
@@ -985,6 +994,7 @@
 				4A54DD2A29CC2122005A3E20 /* Logo.swift in Sources */,
 				4A54DD2B29CC2122005A3E20 /* TagManager.swift in Sources */,
 				4A54DD2C29CC2122005A3E20 /* DreamCalendar.xcdatamodeld in Sources */,
+				4A0C2E922A55595B0008B815 /* WarningImage.swift in Sources */,
 				4A54DD2D29CC2122005A3E20 /* MainTopLeftView.swift in Sources */,
 				4A54DD2E29CC2122005A3E20 /* TagPicker.swift in Sources */,
 				4A54DD2F29CC2122005A3E20 /* MainView.swift in Sources */,

--- a/DreamCalendar/DreamCalendar/DreamCalendar.xcdatamodeld/DreamCalendar.xcdatamodel/contents
+++ b/DreamCalendar/DreamCalendar/DreamCalendar.xcdatamodeld/DreamCalendar.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="22A400" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22A400" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="HolidayAnniversary" representedClassName=".HolidayAnniversary" syncable="YES">
         <attribute name="endDate" optional="YES" attributeType="Date" defaultDateTimeInterval="-3187326472" usesScalarValueType="NO"/>
         <attribute name="repeated" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>

--- a/DreamCalendar/DreamCalendar/DreamCalendarApp.swift
+++ b/DreamCalendar/DreamCalendar/DreamCalendarApp.swift
@@ -14,15 +14,17 @@ struct DreamCalendarApp: App {
     @ObservedObject private var accountManager: AccountManager = AccountManager.global
     @State private var didError: Bool = false
     @State private var error: Error? = nil
+    private let scheduleManager: ScheduleManager = ScheduleManager(viewContext: PersistenceController.shared.container.viewContext)
 
     var body: some Scene {
         WindowGroup {
             switch self.accountManager.didLogin {
             case true :
-                MainView(viewModel: MainViewModel(self.persistenceController.container.viewContext))
+                MainView(viewModel: MainViewModel(self.scheduleManager))
                     .environment(\.managedObjectContext, persistenceController.container.viewContext)
             case false :
-                LoginView(viewModel: LoginViewModel())
+                LoginView(viewModel: LoginViewModel(scheduleManager: self.scheduleManager))
+                    .environment(\.managedObjectContext, persistenceController.container.viewContext)
             default :
                 ActivityIndicator(isAnimating: Binding<Bool?>(get: { return nil }, set: { _, _ in }), style: .large)
                     .alert(DCError.title, isPresented: self.$didError) {

--- a/DreamCalendar/DreamCalendar/DreamCalendarApp.swift
+++ b/DreamCalendar/DreamCalendar/DreamCalendarApp.swift
@@ -53,7 +53,7 @@ struct DreamCalendarApp: App {
     private func presentFirstPage() {
         Task {
             do {
-                try await AccountManager.global.tokenLogin()
+                try await AccountManager.global.tokenLogin(with: self.scheduleManager)
             } catch {
                 self.error = error
                 self.didError = true

--- a/DreamCalendar/DreamCalendar/Extensions/Extension+NotificationCenter.swift
+++ b/DreamCalendar/DreamCalendar/Extensions/Extension+NotificationCenter.swift
@@ -1,0 +1,12 @@
+//
+//  Extension+NotificationCenter.swift
+//  DreamCalendar
+//
+//  Created by 이지수 on 2023/07/05.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let backgroundUpdated: Notification.Name = NSNotification.Name("BackgroundUpdated") 
+}

--- a/DreamCalendar/DreamCalendar/Global/Model/AccountManager.swift
+++ b/DreamCalendar/DreamCalendar/Global/Model/AccountManager.swift
@@ -21,7 +21,7 @@ final class AccountManager: ObservableObject {
     }
     
     @MainActor
-    func tokenLogin() async throws {
+    func tokenLogin(with scheduleManager: ScheduleManager) async throws {
         guard let accessToken = self.user.accessToken else {
             self.didLogin = false
             return
@@ -33,16 +33,17 @@ final class AccountManager: ObservableObject {
         case 200 :
             self.didLogin = true
         case 401 :
-            try await refreshToken()
+            try await refreshToken(with: scheduleManager)
         default :
-            self.user.accessToken = nil
-            self.user.refreshToken = nil
+            self.user.reset()
+            try scheduleManager.deleteAll()
+            try TagManager.global.reinitializeAll()
             self.didLogin = false
         }
     }
     
     @MainActor
-    private func refreshToken() async throws {
+    private func refreshToken(with scheduleManager: ScheduleManager) async throws {
         guard let refreshToken = self.user.refreshToken else {
             self.didLogin = false
             return
@@ -58,8 +59,9 @@ final class AccountManager: ObservableObject {
                 self.didLogin = true
             }
         default :
-            self.user.accessToken = nil
-            self.user.refreshToken = nil
+            self.user.reset()
+            try scheduleManager.deleteAll()
+            try TagManager.global.reinitializeAll()
             self.didLogin = false
         }
     }

--- a/DreamCalendar/DreamCalendar/Global/Model/AccountManager.swift
+++ b/DreamCalendar/DreamCalendar/Global/Model/AccountManager.swift
@@ -81,7 +81,7 @@ final class AccountManager: ObservableObject {
     }
     
     @MainActor
-    func login(email: String, password: String) async throws {
+    func login(email: String, password: String, scheduleManager: ScheduleManager) async throws {
         let apiInfo: APIInfo
         
         #if DEVELOP
@@ -121,7 +121,12 @@ final class AccountManager: ObservableObject {
                 self.user.accessToken = response.access_token
                 self.user.refreshToken = response.refresh_token
             }
-            self.didLogin = true
+            do {
+                self.didLogin = try await scheduleManager.fetchAll()
+            } catch {
+                self.user.reset()
+                throw error
+            }
         case 404 :
             break
         default :

--- a/DreamCalendar/DreamCalendar/Global/Model/AccountManager.swift
+++ b/DreamCalendar/DreamCalendar/Global/Model/AccountManager.swift
@@ -129,10 +129,10 @@ final class AccountManager: ObservableObject {
                 self.user.reset()
                 throw error
             }
-        case 404 :
-            break
-        default :
+        case 500..<600 :
             throw DCError.serverError
+        default :
+            throw DCError.unknown
         }
     }
     

--- a/DreamCalendar/DreamCalendar/Global/Model/ScheduleManager.swift
+++ b/DreamCalendar/DreamCalendar/Global/Model/ScheduleManager.swift
@@ -25,6 +25,7 @@ final class ScheduleManager {
         
         self.cancellable = self.$localCommitLog
             .dropFirst(2)
+            .removeDuplicates()
             .sink(receiveValue: { [weak self] logs in
                 guard logs.isEmpty == false ,
                       let accessToken = AccountManager.global.user.accessToken,

--- a/DreamCalendar/DreamCalendar/Global/Model/ScheduleManager.swift
+++ b/DreamCalendar/DreamCalendar/Global/Model/ScheduleManager.swift
@@ -6,14 +6,90 @@
 //
 
 import CoreData
+import Combine
 
 final class ScheduleManager {
     
     private let viewContext: NSManagedObjectContext
-    private var scheduleAdditionViewModel: ScheduleAdditionViewModel? = nil
+    private var scheduleAdditionViewModel: ScheduleAdditionViewModel?
+    @Published private var localCommitLog: [ScheduleUpdateLog]
+    private var cancellable: AnyCancellable?
+    
+    private var networkManager: NetworkManager?
     
     init(viewContext: NSManagedObjectContext) {
         self.viewContext = viewContext
+        self.scheduleAdditionViewModel = nil
+        self.networkManager = nil
+        self.localCommitLog = []
+        
+        self.cancellable = self.$localCommitLog
+            .dropFirst(2)
+            .sink(receiveValue: { [weak self] logs in
+                guard logs.isEmpty == false ,
+                      let accessToken = AccountManager.global.user.accessToken,
+                      let self = self else { return }
+                Task {
+                    try await self.pushLocalCommitLog(logs, withAccessToken: accessToken)
+                    self.refreshLocalCommitLogs()
+                }
+            })
+        
+        let request = ScheduleUpdateLog.fetchRequest()
+        self.localCommitLog = ((try? self.viewContext.fetch(request)) ?? []).sorted(by: { $0.createdDate < $1.createdDate })
+        
+        self.networkManager = NetworkManager() { [weak self] path in
+            guard path.status == .satisfied,
+                  let accessToken = AccountManager.global.user.accessToken,
+                  let self = self,
+                  self.localCommitLog.isEmpty == false else { return }
+            Task {
+                try await self.pushLocalCommitLog(self.localCommitLog, withAccessToken: accessToken)
+                self.refreshLocalCommitLogs()
+            }
+        }
+        self.networkManager?.startMonitoring()
+    }
+    
+    deinit {
+        self.networkManager?.stopMonitoring()
+        self.networkManager = nil
+    }
+    
+    private func refreshLocalCommitLogs() {
+        let request = ScheduleUpdateLog.fetchRequest()
+        self.localCommitLog = ((try? self.viewContext.fetch(request)) ?? []).sorted(by: { $0.createdDate < $1.createdDate })
+    }
+    
+    private func pushLocalCommitLog(_ localCommitLogs: [ScheduleUpdateLog], withAccessToken accessToken: String) async throws {
+        for log in localCommitLogs {
+            guard let logType = UpdateLogType(rawValue: Int(log.type)) else { continue }
+            let apiInfo: DCAPI.Schedule
+            switch logType {
+            case .create :
+                apiInfo = DCAPI.Schedule.add(accessToken: accessToken,
+                                             title: log.schedule.title,
+                                             tag: Int(log.schedule.tag.id),
+                                             isAllDay: log.schedule.isAllDay,
+                                             startDate: log.schedule.startTime,
+                                             endDate: log.schedule.endTime)
+            case .delete :
+                apiInfo = DCAPI.Schedule.delete(accessToken: accessToken, serverId: log.schedule.serverId)
+            case .update :
+                apiInfo = DCAPI.Schedule.modify(accessToken: accessToken,
+                                                serverId: log.schedule.serverId,
+                                                title: log.schedule.title,tag: Int(log.schedule.tag.id),
+                                                isAllDay: log.schedule.isAllDay,
+                                                startDate: log.schedule.startTime,
+                                                endDate: log.schedule.endTime)
+            }
+            do {
+                try await self.requestBy(log: log, with: apiInfo)
+            } catch {
+                break
+            }
+        }
+        try self.viewContext.save()
     }
     
     private func monthRangePredicate(withDate date: Date) -> NSPredicate {
@@ -59,61 +135,38 @@ final class ScheduleManager {
         try self.viewContext.save()
     }
     
-    func addSchedule(_ schedule: Schedule) throws {
+    func addSchedule(_ schedule: Schedule) async throws {
         let log = schedule.createLog(self.viewContext, type: .create)
         try self.viewContext.save()
-        
-        guard let accessToken = AccountManager.global.user.accessToken else { return }
-        let apiInfo = DCAPI.Schedule.add(accessToken: accessToken,
-                                         title: schedule.title,
-                                         tag: Int(schedule.tag.id),
-                                         isAllDay: schedule.isAllDay,
-                                         startDate: schedule.startTime,
-                                         endDate: schedule.endTime)
-        try self.request(apiInfo, updatedSchedule: schedule, withLog: log)
+        self.localCommitLog.append(log)
     }
     
-    func modifySchedule(_ schedule: Schedule) throws {
+    func modifySchedule(_ schedule: Schedule) async throws {
         let log = schedule.createLog(self.viewContext, type: .update)
         try self.viewContext.save()
-        
-        guard let accessToken = AccountManager.global.user.accessToken else { return }
-        let apiInfo = DCAPI.Schedule.modify(accessToken: accessToken,
-                                            serverId: schedule.serverId,
-                                            title: schedule.title,
-                                            tag: Int(schedule.tag.id),
-                                            isAllDay: schedule.isAllDay,
-                                            startDate: schedule.startTime,
-                                            endDate: schedule.endTime)
-        try self.request(apiInfo, updatedSchedule: schedule, withLog: log)
+        self.localCommitLog.append(log)
     }
     
-    func deleteSchedule(_ schedule: Schedule) throws {
-        let log = schedule.createLog(self.viewContext, type: .delete)
+    func deleteSchedule(_ schedule: Schedule) async throws {
         schedule.isValid = false
+        let log = schedule.createLog(self.viewContext, type: .delete)
         try self.viewContext.save()
-        
-        guard schedule.serverId != 0,
-              let accessToken = AccountManager.global.user.accessToken else { return }
-        let apiInfo = DCAPI.Schedule.delete(accessToken: accessToken,
-                                            serverId: schedule.serverId)
-        try self.request(apiInfo, updatedSchedule: schedule, withLog: log)
+        self.localCommitLog.append(log)
     }
     
-    private func request(_ apiInfo: APIInfo, updatedSchedule schedule: Schedule, withLog log: ScheduleUpdateLog) throws {
-        do {
-            Task {
-                let (statusCode, data) = try await DCRequest().request(with: apiInfo)
-                switch statusCode {
-                case 200..<300 :
-                    guard let response = try apiInfo.response(data) as? DCAPI.ScheduleResponse else { return }
-                    schedule.serverId = response.id
-                    self.viewContext.delete(log)
-                    try self.viewContext.save()
-                default :
-                    return
-                }
+    private func requestBy(log: ScheduleUpdateLog, with apiInfo: APIInfo) async throws {
+        let (statusCode, data) = try await DCRequest().request(with: apiInfo)
+        switch statusCode {
+        case 200..<300 :
+            if let response = try? apiInfo.response(data) as? DCAPI.ScheduleResponse,
+               log.schedule.serverId == 0 {
+                log.schedule.serverId = response.id
             }
+            self.viewContext.delete(log)
+        case 500..<600 :
+            throw DCError.serverError
+        default :
+            throw DCError.unknown
         }
     }
     
@@ -153,6 +206,17 @@ final class ScheduleManager {
         guard let deleteResult = batchDelete?.result as? [NSManagedObjectID] else { throw DCError.batchError }
         let deletedObjects: [AnyHashable: Any] = [ NSDeletedObjectsKey: deleteResult ]
         NSManagedObjectContext.mergeChanges(fromRemoteContextSave: deletedObjects, into: [self.viewContext])
+        
+        let logRequest: NSFetchRequest<NSFetchRequestResult> = ScheduleUpdateLog.fetchRequest()
+        let logDeleteRequest = NSBatchDeleteRequest(fetchRequest: logRequest)
+        logDeleteRequest.resultType = .resultTypeObjectIDs
+        
+        let logBatchDelete = try self.viewContext.execute(logDeleteRequest) as? NSBatchDeleteResult
+        guard let logDeleteResult = logBatchDelete?.result as? [NSManagedObjectID] else { throw DCError.batchError }
+        let logDeletedObjects: [AnyHashable: Any] = [ NSDeletedObjectsKey: logDeleteResult ]
+        NSManagedObjectContext.mergeChanges(fromRemoteContextSave: logDeletedObjects, into: [self.viewContext])
+        
+        self.localCommitLog = []
     }
     
     func fetchAll() async throws -> Bool {
@@ -192,5 +256,27 @@ fileprivate extension String {
     
     var serverDate: Date? {
         return Self.serverDateFormatter.date(from: self)
+    }
+}
+
+
+//MARK: NetworkManager
+import Network
+
+fileprivate final class NetworkManager {
+    private let monitor: NWPathMonitor
+    private(set) var isConnected: Bool = false
+    
+    init(_ handler: @escaping (NWPath) -> Void) {
+        self.monitor = NWPathMonitor()
+        self.monitor.pathUpdateHandler = handler
+    }
+
+    public func startMonitoring() {
+        self.monitor.start(queue: DispatchQueue.global())
+    }
+
+    public func stopMonitoring() {
+        self.monitor.cancel()
     }
 }

--- a/DreamCalendar/DreamCalendar/Global/Model/ScheduleManager.swift
+++ b/DreamCalendar/DreamCalendar/Global/Model/ScheduleManager.swift
@@ -39,7 +39,7 @@ final class ScheduleManager {
                                                   mode: mode,
                                                   date: date)
         } else {
-            let schedule = getNewSchedule(in: date)
+            let schedule = self.getNewSchedule(in: date)
             viewModel = ScheduleAdditionViewModel(self,
                                                   delegate: delegate,
                                                   schedule: schedule,
@@ -96,12 +96,7 @@ final class ScheduleManager {
         guard schedule.serverId != 0,
               let accessToken = AccountManager.global.user.accessToken else { return }
         let apiInfo = DCAPI.Schedule.delete(accessToken: accessToken,
-                                            serverId: schedule.serverId,
-                                            title: schedule.title,
-                                            tag: Int(schedule.tag.id),
-                                            isAllDay: schedule.isAllDay,
-                                            startDate: schedule.startTime,
-                                            endDate: schedule.endTime)
+                                            serverId: schedule.serverId)
         try self.request(apiInfo, updatedSchedule: schedule, withLog: log)
     }
     
@@ -152,8 +147,50 @@ final class ScheduleManager {
     func deleteAll() throws {
         let request: NSFetchRequest<NSFetchRequestResult> = Schedule.fetchRequest()
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+        deleteRequest.resultType = .resultTypeObjectIDs
         
-        try self.viewContext.execute(deleteRequest)
+        let batchDelete = try self.viewContext.execute(deleteRequest) as? NSBatchDeleteResult
+        guard let deleteResult = batchDelete?.result as? [NSManagedObjectID] else { throw DCError.batchError }
+        let deletedObjects: [AnyHashable: Any] = [ NSDeletedObjectsKey: deleteResult ]
+        NSManagedObjectContext.mergeChanges(fromRemoteContextSave: deletedObjects, into: [self.viewContext])
+    }
+    
+    func fetchAll() async throws -> Bool {
+        guard let accessToken = AccountManager.global.user.accessToken else { throw DCError.accountError }
+        let apiInfo = DCAPI.Schedule.schedules(accessToken: accessToken)
+        let (statusCode, data) = try await DCRequest().request(with: apiInfo)
+        switch statusCode {
+        case 200..<300 :
+            guard let response = try apiInfo.response(data) as? [DCAPI.ScheduleResponse] else { throw DCError.decodingError(data) }
+            try response.forEach() { schedule in
+                guard let startDate = schedule.start_at?.serverDate,
+                      let endDate = schedule.end_at?.serverDate else { throw DCError.decodingError(data) }
+                let newSchedule = Schedule(context: self.viewContext)
+                newSchedule.id = UUID()
+                newSchedule.title = schedule.title
+                newSchedule.isAllDay = schedule.is_all_day
+                newSchedule.startTime = startDate
+                newSchedule.endTime = endDate
+                newSchedule.tagId = Int16(schedule.tag)
+                newSchedule.isValid = true
+                newSchedule.serverId = schedule.id
+            }
+            try self.viewContext.save()
+            return true
+        default :
+            return false
+        }
     }
 }
 
+fileprivate extension String {
+    static let serverDateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
+        return dateFormatter
+    }()
+    
+    var serverDate: Date? {
+        return Self.serverDateFormatter.date(from: self)
+    }
+}

--- a/DreamCalendar/DreamCalendar/Global/Model/ScheduleManager.swift
+++ b/DreamCalendar/DreamCalendar/Global/Model/ScheduleManager.swift
@@ -12,8 +12,11 @@ final class ScheduleManager {
     
     private let viewContext: NSManagedObjectContext
     private var scheduleAdditionViewModel: ScheduleAdditionViewModel?
-    @Published private var localCommitLog: [ScheduleUpdateLog]
+    @Published private(set) var localCommitLog: [ScheduleUpdateLog]
     private var cancellable: AnyCancellable?
+    var notUpdatedSchedules: [Schedule] {
+        return self.localCommitLog.map({ $0.schedule })
+    }
     
     private var networkManager: NetworkManager?
     
@@ -60,6 +63,8 @@ final class ScheduleManager {
     private func refreshLocalCommitLogs() {
         let request = ScheduleUpdateLog.fetchRequest()
         self.localCommitLog = ((try? self.viewContext.fetch(request)) ?? []).sorted(by: { $0.createdDate < $1.createdDate })
+        
+        NotificationCenter.default.post(name: .backgroundUpdated, object: nil, userInfo: nil);
     }
     
     private func pushLocalCommitLog(_ localCommitLogs: [ScheduleUpdateLog], withAccessToken accessToken: String) async throws {

--- a/DreamCalendar/DreamCalendar/Global/Model/TagManager.swift
+++ b/DreamCalendar/DreamCalendar/Global/Model/TagManager.swift
@@ -49,6 +49,9 @@ final class TagManager {
         try self.viewContext.save()
         let tags = try self.fetchAllTag()
         tags.forEach() { tag in
+            if self.tags[Int(tag.id)] != tag {
+                // TODO: TagUpdateLog 기록 추가
+            }
             self.tags.updateValue(tag, forKey: Int(tag.id))
         }
     }
@@ -59,6 +62,8 @@ final class TagManager {
             tag.order = tag.type.defaultOrder
             tag.title = tag.type.defaultTitle
         }
+        
+        
         try self.viewContext.save()
     }
     

--- a/DreamCalendar/DreamCalendar/Global/Network/DCAccountAPI.swift
+++ b/DreamCalendar/DreamCalendar/Global/Network/DCAccountAPI.swift
@@ -112,7 +112,7 @@ final class DCAPI {
             do {
                 return try JSONDecoder().decode(responseType, from: data)
             } catch {
-                throw DCError.decodingError(error)
+                throw DCError.decodingError(data)
             }
         }
     }

--- a/DreamCalendar/DreamCalendar/Global/Network/DCAdminAPI.swift
+++ b/DreamCalendar/DreamCalendar/Global/Network/DCAdminAPI.swift
@@ -58,7 +58,7 @@ extension DCAPI {
             do {
                 return try JSONDecoder().decode(responseType, from: data)
             } catch {
-                throw DCError.decodingError(error)
+                throw DCError.decodingError(data)
             }
         }
     }

--- a/DreamCalendar/DreamCalendar/Global/Network/DCRequest.swift
+++ b/DreamCalendar/DreamCalendar/Global/Network/DCRequest.swift
@@ -20,20 +20,28 @@ fileprivate struct NetworkContainer {
         
         """)
         
-        let (data, response) = try await URLSession.shared.data(for: request)
-        print("""
-        
-        Response >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-        statusCode : \((response as? HTTPURLResponse)?.statusCode ?? 0)
-        data : \(String(data: data, encoding: String.Encoding.utf8) ?? "nil")
-        <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-        
-        """)
-        guard let httpResponse = response as? HTTPURLResponse,
-              (100..<500) ~= httpResponse.statusCode else {
-            throw DCError.network(response)
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            
+            print("""
+            
+            Response >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+            statusCode : \((response as? HTTPURLResponse)?.statusCode ?? 0)
+            data : \(String(data: data, encoding: String.Encoding.utf8) ?? "nil")
+            <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+            
+            """)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (100..<500) ~= httpResponse.statusCode else {
+                throw DCError.network(response)
+            }
+            if httpResponse.statusCode == 408 {
+                throw DCError.network(response)
+            }
+            return (httpResponse.statusCode, data)
+        } catch {
+            throw DCError.connection
         }
-        return (httpResponse.statusCode, data)
     }
 }
 

--- a/DreamCalendar/DreamCalendar/Global/Network/DCScheduleAPI.swift
+++ b/DreamCalendar/DreamCalendar/Global/Network/DCScheduleAPI.swift
@@ -20,15 +20,15 @@ extension DCAPI {
     
     enum Schedule: APIInfo {
         case add(accessToken: String, title: String, tag: Int, isAllDay: Bool, startDate: Date, endDate: Date)
-        case schedule(accessToken: String, serverId: Int)
+        case schedule(accessToken: String, serverId: Int64)
         case schedules(accessToken: String)
         case modify(accessToken: String, serverId: Int64, title: String, tag: Int, isAllDay: Bool, startDate: Date, endDate: Date)
-        case delete(accessToken: String, serverId: Int64, title: String, tag: Int, isAllDay: Bool, startDate: Date, endDate: Date)
+        case delete(accessToken: String, serverId: Int64)
         
         var route: String {
             switch self {
-            case .add, .modify, .delete: return "/schedule"
-            case .schedule(_, let id): return "/schedule/\(id)"
+            case .add: return "/schedule"
+            case .schedule(_, let id), .modify(_, let id, _, _, _, _, _), .delete(_, let id): return "/schedule/\(id)"
             case .schedules: return "/schedules"
             }
         }
@@ -44,7 +44,7 @@ extension DCAPI {
         
         var header: [(key: String, value: String)]? {
             switch self {
-            case .add(let accessToken, _, _, _, _, _), .schedule(let accessToken, _), .schedules(let accessToken), .modify(let accessToken, _, _, _, _, _, _), .delete(let accessToken, _, _, _, _, _, _) :
+            case .add(let accessToken, _, _, _, _, _), .schedule(let accessToken, _), .schedules(let accessToken), .modify(let accessToken, _, _, _, _, _, _), .delete(let accessToken, _) :
                 return [("Content-Type", "application/json"), ("Authorization", accessToken)]
             }
         }
@@ -55,7 +55,7 @@ extension DCAPI {
             switch self {
             case .add(_, let title, let tag, let isAllDay, let startDate, let endDate) :
                 body = ["title": title, "tag": tag, "is_all_day": isAllDay, "start_at": startDate.serverString, "end_at": endDate.serverString]
-            case .modify(_, let serverId, let title, let tag, let isAllDay, let startDate, let endDate), .delete(_, let serverId, let title, let tag, let isAllDay, let startDate, let endDate) :
+            case .modify(_, let serverId, let title, let tag, let isAllDay, let startDate, let endDate) :
                 body = ["id": serverId, "title": title, "tag": tag, "is_all_day": isAllDay, "start_at": startDate.serverString, "end_at": endDate.serverString]
             default :
                 return nil
@@ -83,7 +83,7 @@ extension DCAPI {
             do {
                 return try JSONDecoder().decode(responseType, from: data)
             } catch {
-                throw DCError.decodingError(error)
+                throw DCError.decodingError(data)
             }
         }
     }

--- a/DreamCalendar/DreamCalendar/Models/Schedule+CoreDataClass.swift
+++ b/DreamCalendar/DreamCalendar/Models/Schedule+CoreDataClass.swift
@@ -22,7 +22,7 @@ public class Schedule: NSManagedObject {
 import CalendarUI
 
 extension Schedule {
-    var scheduleForUI: CalendarUI.Schedule {
+    func scheduleForUI(isNotUpdated: Bool) -> CalendarUI.Schedule {
         let schedule = CalendarUI.Schedule(id: self.id,
                                            serverId: Int(self.serverId),
                                            title: self.title,
@@ -30,7 +30,8 @@ extension Schedule {
                                            startTime: self.startTime,
                                            endTime: self.endTime,
                                            tag: CalendarUI.TagUI(rawValue: Int(self.tagId)),
-                                           isValid: self.isValid)
+                                           isValid: self.isValid,
+                                           isNotUpdated: isNotUpdated)
         return schedule
     }
 }

--- a/DreamCalendar/DreamCalendar/Models/ScheduleUpdateLog+CoreDataProperties.swift
+++ b/DreamCalendar/DreamCalendar/Models/ScheduleUpdateLog+CoreDataProperties.swift
@@ -13,7 +13,9 @@ import CoreData
 extension ScheduleUpdateLog {
 
     @nonobjc public class func fetchRequest() -> NSFetchRequest<ScheduleUpdateLog> {
-        return NSFetchRequest<ScheduleUpdateLog>(entityName: "ScheduleUpdateLog")
+        let request = NSFetchRequest<ScheduleUpdateLog>(entityName: "ScheduleUpdateLog")
+        request.relationshipKeyPathsForPrefetching = ["schedule"]
+        return request
     }
 
     @NSManaged public var id: UUID

--- a/DreamCalendar/DreamCalendar/Scene/Account/LoginView.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Account/LoginView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-
+import Network
 
 protocol InputableField: View {
     init(_ titleKey: LocalizedStringKey, text: Binding<String>)

--- a/DreamCalendar/DreamCalendar/Scene/Account/LoginViewModel.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Account/LoginViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CoreData
+import Network
 
 final class LoginViewModel: ObservableObject {
     

--- a/DreamCalendar/DreamCalendar/Scene/Account/LoginViewModel.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Account/LoginViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CoreData
 
 final class LoginViewModel: ObservableObject {
     
@@ -14,19 +15,21 @@ final class LoginViewModel: ObservableObject {
     @Published var didError: Bool
     @Published private(set) var loginMessage: String?
     private(set) var error: Error?
+    private let scheduleManager: ScheduleManager
     
-    init(email: String = "", password: String = "") {
+    init(email: String = "", password: String = "", scheduleManager: ScheduleManager) {
         self.email = email
         self.password = password
         self.didError = false
         self.loginMessage = nil
         self.error = nil
+        self.scheduleManager = scheduleManager
     }
     
     @MainActor
     func login() async {
         do {
-            try await AccountManager.global.login(email: self.email, password: self.password)
+            try await AccountManager.global.login(email: self.email, password: self.password, scheduleManager: self.scheduleManager)
             if AccountManager.global.didLogin == false {
                 self.loginMessage = "이메일 또는 비밀번호가 틀렸습니다."
             }

--- a/DreamCalendar/DreamCalendar/Scene/Main/DayScheduleList/DayScheduleListView.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Main/DayScheduleList/DayScheduleListView.swift
@@ -14,7 +14,7 @@ struct DayScheduleListView: View, ScheduleDetailViewDelegate {
     private let delegate: AdditionViewPresentDelegate
     
     private(set) var date: Date
-    private(set) var schedules: [Schedule]
+    private(set) var schedules: [(Schedule, Bool)]
     private let detent: HalfSheet<Self>.Detent
     
     @State private var selectedSchedule: Schedule? = nil
@@ -32,7 +32,7 @@ struct DayScheduleListView: View, ScheduleDetailViewDelegate {
         static let blockTopBottomPadding: CGFloat = 5
     }
     
-    init(delegate: AdditionViewPresentDelegate, viewModel: ObservedObject<MainViewModel>, schedules: [Schedule], detent: HalfSheet<Self>.Detent) {
+    init(delegate: AdditionViewPresentDelegate, viewModel: ObservedObject<MainViewModel>, schedules: [(Schedule, Bool)], detent: HalfSheet<Self>.Detent) {
         self.delegate = delegate
         self._viewModel = viewModel
         self.date = viewModel.wrappedValue.selectedDate
@@ -78,8 +78,8 @@ struct DayScheduleListView: View, ScheduleDetailViewDelegate {
     
     private var scheduleList: some View {
         List {
-            ForEach(self.schedules) { schedule in
-                ScheduleDetailBlock(schedule: schedule)
+            ForEach(self.schedules, id: \.0) { schedule in
+                ScheduleDetailBlock(schedule: schedule.0, isNotUpdated: schedule.1)
                     .listRowInsets(EdgeInsets(top: Constraint.blockTopBottomPadding,
                                               leading: Constraint.blockLeadingTrailingPadding,
                                               bottom: Constraint.blockTopBottomPadding,
@@ -87,7 +87,7 @@ struct DayScheduleListView: View, ScheduleDetailViewDelegate {
                     .listRowSeparator(.hidden)
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        self.selectedSchedule = schedule
+                        self.selectedSchedule = schedule.0
                     }
             }
         }
@@ -124,6 +124,7 @@ struct DayScheduleListView: View, ScheduleDetailViewDelegate {
 struct ScheduleDetailBlock: View {
     
     let schedule: Schedule
+    let isNotUpdated: Bool
     
     private struct Constraint {
         static let zeroPadding: CGFloat = 0
@@ -143,6 +144,9 @@ struct ScheduleDetailBlock: View {
     var body: some View {
         HStack(spacing: Constraint.zeroPadding) {
             self.leftBar
+            if self.isNotUpdated {
+                WarningImage(color: self.schedule.tagType.color)
+            }
             self.title
             if self.schedule.isAllDay {
                 self.allDayInfo

--- a/DreamCalendar/DreamCalendar/Scene/Main/MainView.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Main/MainView.swift
@@ -149,7 +149,7 @@ struct MainView: View, MainTopViewDelegate {
 enum DCError: Error {
     static let title: String = "오류"
     
-    case unknown, coreData(Error), network(URLResponse), urlError, requestError(Error), decodingError(Error), serverError, accountError
+    case unknown, coreData(Error), network(URLResponse), urlError, requestError(Error), decodingError(Data), serverError, accountError, batchError
     
     var message: String {
         switch self {
@@ -161,6 +161,7 @@ enum DCError: Error {
         case .decodingError: return "서버 오류입니다. \n관리자에게 문의해주세요."
         case .serverError: return "서버 오류입니다. \n관리자에게 문의해주세요."
         case .accountError: return "계정 정보 오류입니다. \n재접속 해주세요."
+        case .batchError: return "코어 데이터 오류입니다. \n앱을 재시동 해주세요."
         }
     }
 }

--- a/DreamCalendar/DreamCalendar/Scene/Main/MainView.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Main/MainView.swift
@@ -57,15 +57,16 @@ struct MainView: View, MainTopViewDelegate {
                     self.calendarViewIndex = CGFloat(MainViewModel.centerIndex) - (value.translation.width / proxy.size.width)
                 }
                 .onEnded { value in
+                    // TODO: 속도 반영하여 스와이핑
                     let index: CGFloat
-                    if abs(value.translation.width) >= proxy.size.width / 2 {
+                    if abs(value.translation.width) >= proxy.size.width / 3 {
                         let addition = value.translation.width > 0 ? 0 : 1
                         index = CGFloat((Int(self.calendarViewIndex) + addition))
                     } else {
                         let addition = value.translation.width > 0 ? 1 : 0
                         index = CGFloat(Int(self.calendarViewIndex) + addition)
                     }
-                    let duration: CGFloat = ((proxy.size.width - abs(value.translation.width)) / proxy.size.width)
+                    let duration: CGFloat = ((proxy.size.width - abs(value.translation.width)) / (proxy.size.width * 2))
                     withAnimation(.easeOut(duration: duration)) {
                         self.calendarViewIndex = CGFloat(MainViewModel.centerIndex)
                         self.viewModel.changeIndex(Int(index))

--- a/DreamCalendar/DreamCalendar/Scene/Main/MainView.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Main/MainView.swift
@@ -150,7 +150,7 @@ struct MainView: View, MainTopViewDelegate {
 enum DCError: Error {
     static let title: String = "오류"
     
-    case unknown, coreData(Error), network(URLResponse), urlError, requestError(Error), decodingError(Data), serverError, accountError, batchError
+    case unknown, coreData(Error), network(URLResponse), urlError, requestError(Error), decodingError(Data), serverError, accountError, batchError, connection
     
     var message: String {
         switch self {
@@ -163,6 +163,7 @@ enum DCError: Error {
         case .serverError: return "서버 오류입니다. \n관리자에게 문의해주세요."
         case .accountError: return "계정 정보 오류입니다. \n재접속 해주세요."
         case .batchError: return "코어 데이터 오류입니다. \n앱을 재시동 해주세요."
+        case .connection : return "네트워크 연결에 실패했습니다.\n네트워크 환경을 확인해주세요."
         }
     }
 }

--- a/DreamCalendar/DreamCalendar/Scene/Main/MainView.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Main/MainView.swift
@@ -76,11 +76,11 @@ struct MainView: View, MainTopViewDelegate {
     }
     
     @ViewBuilder
-    private func calendarView(with schedules: [Schedule], at date: Date) -> some View {
+    private func calendarView(with schedules: [(Schedule, Bool)], at date: Date) -> some View {
         VStack(spacing: Constraint.zeroPadding) {
             CalendarView(defaultDate: date,
                          selectedDate: self.$viewModel.selectedDate,
-                         schedules: schedules.map({$0.scheduleForUI}),
+                         schedules: schedules.map({$0.0.scheduleForUI(isNotUpdated: $0.1 == false)}),
                          isShortMode: self.viewModel.isDetailMode)
             Spacer()
         }

--- a/DreamCalendar/DreamCalendar/Scene/Main/MainViewModel.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Main/MainViewModel.swift
@@ -159,11 +159,13 @@ final class MainViewModel: ObservableObject, DateManipulationDelegate, AdditionV
     }
     
     private func fetchAllSchedules(with current: Date) {
-        self.fetchSchedules(with: current.previousMonth.previousMonth)
-        self.fetchSchedules(with: current.previousMonth)
-        self.fetchSchedules(with: current)
-        self.fetchSchedules(with: current.nextMonth)
-        self.fetchSchedules(with: current.nextMonth.nextMonth)
+        DispatchQueue.main.async {
+            self.fetchSchedules(with: current.previousMonth.previousMonth)
+            self.fetchSchedules(with: current.previousMonth)
+            self.fetchSchedules(with: current)
+            self.fetchSchedules(with: current.nextMonth)
+            self.fetchSchedules(with: current.nextMonth.nextMonth)
+        }
     }
     
     private func fetchSchedules(with date: Date) {
@@ -229,8 +231,10 @@ final class MainViewModel: ObservableObject, DateManipulationDelegate, AdditionV
     }
     
     func refreshMainViewSchedule() {
-        self.fetchAllSchedules(with: self.date)
-        self.schedulesForSelectedDate = schedulesOnDate(date: self.selectedDate)
+        DispatchQueue.main.async {
+            self.fetchAllSchedules(with: self.date)
+            self.schedulesForSelectedDate = self.schedulesOnDate(date: self.selectedDate)
+        }
     }
     
     private func schedulesOnDate(date: Date) -> [Schedule] {

--- a/DreamCalendar/DreamCalendar/Scene/Main/MainViewModel.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Main/MainViewModel.swift
@@ -42,9 +42,9 @@ final class MainViewModel: ObservableObject, DateManipulationDelegate, AdditionV
         return self.schedules.map({ (date: $0.key, schedules: $0.value) }).sorted(by: { $0.date < $1.date })
     }
     
-    init(_ context: NSManagedObjectContext, selectedYear: Int? = nil, month selectedMonth: Int? = nil, day selectedDay: Int? = 32) {
+    init(_ scheduleManager: ScheduleManager, selectedYear: Int? = nil, month selectedMonth: Int? = nil, day selectedDay: Int? = 32) {
         
-        self.scheduleManager = ScheduleManager(viewContext: context)
+        self.scheduleManager = scheduleManager
         
         let year: Int, month: Int, day: Int
         var selectedDate = Date()

--- a/DreamCalendar/DreamCalendar/Scene/ScheduleAddition/ScheduleAdditionViewModel.swift
+++ b/DreamCalendar/DreamCalendar/Scene/ScheduleAddition/ScheduleAdditionViewModel.swift
@@ -94,23 +94,27 @@ final class ScheduleAdditionViewModel: ObservableObject {
     }
     
     func uploadScheduleButtonDidTouched() {
-        do {
-            self.removeAllBinding()
-            switch self.mode {
-            case .modify :
-                try self.scheduleManager.modifySchedule(self.schedule)
-            case .create :
-                try self.scheduleManager.addSchedule(self.schedule)
-            default :
-                break
+        Task {
+            do {
+                self.removeAllBinding()
+                switch self.mode {
+                case .modify :
+                    try await self.scheduleManager.modifySchedule(self.schedule)
+                case .create :
+                    try await self.scheduleManager.addSchedule(self.schedule)
+                default :
+                    break
+                }
+                self.scheduleManager.removeScheduleAdditionViewModel()
+                self.completeExplicitButtonAction()
+                
+                self.delegate.refreshMainViewSchedule()
+                self.delegate.closeAdditionSheet()
+            } catch {
+                DispatchQueue.main.async {
+                    self.error = error
+                }
             }
-            self.scheduleManager.removeScheduleAdditionViewModel()
-            self.completeExplicitButtonAction()
-            
-            self.delegate.refreshMainViewSchedule()
-            self.delegate.closeAdditionSheet()
-        } catch {
-            self.error = error
         }
     }
     

--- a/DreamCalendar/DreamCalendar/Scene/ScheduleDetail/ScheduleDetailView.swift
+++ b/DreamCalendar/DreamCalendar/Scene/ScheduleDetail/ScheduleDetailView.swift
@@ -23,6 +23,9 @@ struct ScheduleDetailView: View {
         static let timeInfoInterval: CGFloat = 20
         static let circleTagTitleInterval: CGFloat = 5
         
+        static let warningImageHeightWidth: CGFloat = 10
+        static let titleImageInterval: CGFloat = 2
+        
         static let tagTitle: String = "태그"
         
         static let menuEditButtonTitle: String = "수정"
@@ -91,6 +94,9 @@ struct ScheduleDetailView: View {
                                     leading: Constraint.zeroPadding,
                                     bottom: Constraint.zeroPadding,
                                     trailing: Constraint.circleTagTitleInterval))
+            if self.viewModel.scheduleIsNotUpdated == true {
+                WarningImage(color: self.viewModel.schedule.tagType.color)
+            }
             Text(self.viewModel.schedule.title)
                 .font(.AppleSDBold16)
                 .foregroundColor(.black)

--- a/DreamCalendar/DreamCalendar/Scene/ScheduleDetail/ScheduleDetailViewModel.swift
+++ b/DreamCalendar/DreamCalendar/Scene/ScheduleDetail/ScheduleDetailViewModel.swift
@@ -63,9 +63,11 @@ final class ScheduleDetailViewModel: ObservableObject {
     
     func deleteSchedule() {
         do {
-            try self.scheduleManager.deleteSchedule(self.schedule)
-            self.scheduleEditingDelegate.refreshMainViewSchedule()
-            self.delegate.closeDetailView()
+            Task {
+                try await self.scheduleManager.deleteSchedule(self.schedule)
+                self.scheduleEditingDelegate.refreshMainViewSchedule()
+                self.delegate.closeDetailView()
+            }
         } catch {
             self.error = error
         }

--- a/DreamCalendar/DreamCalendar/Scene/ScheduleDetail/ScheduleDetailViewModel.swift
+++ b/DreamCalendar/DreamCalendar/Scene/ScheduleDetail/ScheduleDetailViewModel.swift
@@ -17,6 +17,7 @@ final class ScheduleDetailViewModel: ObservableObject {
     private let date: Date
     private let delegate: ScheduleDetailViewDelegate
     let scheduleEditingDelegate: AdditionViewPresentDelegate & RefreshMainViewDelegate
+    let scheduleIsNotUpdated: Bool
     
     @Published var isEditingMode: Bool = false
     @Published private(set) var error: Error? = nil
@@ -51,6 +52,7 @@ final class ScheduleDetailViewModel: ObservableObject {
         self.date = date
         self.delegate = delegate
         self.scheduleEditingDelegate = scheduleEditingDelegate
+        self.scheduleIsNotUpdated = scheduleManager.notUpdatedSchedules.contains(schedule)
     }
     
     func closeDetailView() {
@@ -62,14 +64,14 @@ final class ScheduleDetailViewModel: ObservableObject {
     }
     
     func deleteSchedule() {
-        do {
-            Task {
+        Task {
+            do {
                 try await self.scheduleManager.deleteSchedule(self.schedule)
                 self.scheduleEditingDelegate.refreshMainViewSchedule()
                 self.delegate.closeDetailView()
+            } catch {
+                self.error = error
             }
-        } catch {
-            self.error = error
         }
     }
     

--- a/DreamCalendar/DreamCalendar/Scene/Setting/SettingsView.swift
+++ b/DreamCalendar/DreamCalendar/Scene/Setting/SettingsView.swift
@@ -117,10 +117,11 @@ struct SettingsView: View {
     private func logout() {
         Task {
             do {
+                try await AccountManager.global.logout()
                 try self.scheduleManager.deleteAll()
                 try TagManager.global.reinitializeAll()
-                try await AccountManager.global.logout()
             } catch {
+                print(error)
                 self.didLogoutError = true
             }
         }

--- a/DreamCalendar/DreamCalendar/Scene/WarningImage.swift
+++ b/DreamCalendar/DreamCalendar/Scene/WarningImage.swift
@@ -1,0 +1,31 @@
+//
+//  WarningImage.swift
+//  DreamCalendar
+//
+//  Created by 이지수 on 2023/07/05.
+//
+
+import SwiftUI
+
+struct WarningImage: View {
+    private struct Constraint {
+        static let imageName: String = "exclamationmark.triangle"
+        static let imageHeight: CGFloat = 10
+        static let imageWidth: CGFloat = 10
+        static let zeroPadding: CGFloat = 0
+        static let trailingInterval: CGFloat = 2
+    }
+    
+    let color: Color
+    
+    var body: some View {
+        Image(systemName: Constraint.imageName)
+            .resizable()
+            .foregroundColor(self.color)
+            .frame(width: Constraint.imageWidth, height: Constraint.imageHeight, alignment: .center)
+            .padding(EdgeInsets(top: Constraint.zeroPadding,
+                                leading: Constraint.zeroPadding,
+                                bottom: Constraint.zeroPadding,
+                                trailing: Constraint.trailingInterval))
+    }
+}


### PR DESCRIPTION
## 작업 내용
- [x] 일정 업데이트 시 서버에 업로드한다.
- [x] 로그인한 계정의 일정을 서버로부터 받아온다.
- [x] 자동로그인에 실패하면 자동으로 로그아웃되어, 계정 정보가 사라진다.
- [x] 네트워크에 연결되지 않은 일정은 추후 네트워크에 연결되면 서버에 업로드 한다.
- [x] 네트워크에 연결되지 않은 일정을 알 수 있도록 화면에 표시한다.

close #40 

## 시연 방법

https://github-production-user-asset-6210df.s3.amazonaws.com/64150179/251081916-9b515086-779c-4ecf-9036-c3c419b64999.mp4


## 기타 (고민과 해결, 리뷰 포인트 등)
- #46



